### PR TITLE
Initial window support, looking for ideas/help

### DIFF
--- a/src/child_frame.rs
+++ b/src/child_frame.rs
@@ -1,0 +1,135 @@
+
+use std::mem::transmute;
+
+use imgui_sys;
+use ImStr;
+use ImVec2;
+use ImGuiWindowFlags;
+
+use super::{
+    ImGuiWindowFlags_NoTitleBar,
+    ImGuiWindowFlags_NoResize,
+    ImGuiWindowFlags_NoMove,
+    ImGuiWindowFlags_NoScrollbar,
+    ImGuiWindowFlags_NoScrollWithMouse,
+    ImGuiWindowFlags_NoCollapse,
+    ImGuiWindowFlags_AlwaysAutoResize,
+    ImGuiWindowFlags_ShowBorders,
+    ImGuiWindowFlags_NoSavedSettings,
+    ImGuiWindowFlags_NoInputs,
+    ImGuiWindowFlags_MenuBar,
+    ImGuiWindowFlags_HorizontalScrollbar,
+    ImGuiWindowFlags_NoFocusOnAppearing,
+    ImGuiWindowFlags_NoBringToFrontOnFocus,
+    ImGuiWindowFlags_AlwaysVerticalScrollbar,
+    ImGuiWindowFlags_AlwaysHorizontalScrollbar,
+    ImGuiWindowFlags_AlwaysUseWindowPadding
+};
+
+#[must_use]
+pub struct ChildFrame<'p> {
+    name: &'p ImStr,
+    size: ImVec2,
+    flags: ImGuiWindowFlags
+}
+
+impl<'p> ChildFrame<'p> {
+    pub fn new(name: &'p ImStr, size: ImVec2) -> ChildFrame<'p> {
+        let empty_flag: ImGuiWindowFlags = unsafe {transmute::<i32, ImGuiWindowFlags>(0) };
+        ChildFrame { name: name, size: size, flags: empty_flag }
+    }
+    #[inline]
+    pub fn show_title(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoTitleBar, !value);
+        self
+    }
+    #[inline]
+    pub fn resizable(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoResize, !value);
+        self
+    }
+    #[inline]
+    pub fn movable(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoMove, !value);
+        self
+    }
+    #[inline]
+    pub fn show_scrollbar(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoScrollbar, !value);
+        self
+    }
+    #[inline]
+    pub fn show_scrollbar_with_mouse(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoScrollWithMouse, !value);
+        self
+    }
+    #[inline]
+    pub fn collapsible(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoCollapse, !value);
+        self
+    }
+    #[inline]
+    pub fn always_resizable(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_AlwaysAutoResize, value);
+        self
+    }
+    #[inline]
+    pub fn show_border(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_ShowBorders, value);
+        self
+    }
+    #[inline]
+    pub fn save_settings(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoSavedSettings, !value);
+        self
+    }
+    #[inline]
+    pub fn input_allow(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoInputs, !value);
+        self
+    }
+    #[inline]
+    pub fn show_menu(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_MenuBar, value);
+        self
+    }
+    #[inline]
+    pub fn scrollbar_horizontal(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_HorizontalScrollbar, value);
+        self
+    }
+    #[inline]
+    pub fn focus_on_appearing(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoFocusOnAppearing, !value);
+        self
+    }
+    #[inline]
+    pub fn bring_to_front_on_focus(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_NoBringToFrontOnFocus, !value);
+        self
+    }
+    #[inline]
+    pub fn always_show_vertical_scroll_bar(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_AlwaysVerticalScrollbar, value);
+        self
+    }
+    #[inline]
+    pub fn always_show_horizontal_scroll_bar(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_AlwaysHorizontalScrollbar, value);
+        self
+    }
+    #[inline]
+    pub fn always_use_window_padding(mut self, value: bool) -> Self {
+        self.flags.set(ImGuiWindowFlags_AlwaysUseWindowPadding, value);
+        self
+    }
+
+    pub fn build<F: FnOnce()>(self, f: F) {
+        unsafe {
+            let show_border = self.flags.contains(ImGuiWindowFlags_ShowBorders);
+            imgui_sys::igBeginChild(self.name.as_ptr(), self.size, show_border, self.flags);
+        }
+        f();
+        unsafe { imgui_sys::igEndChild(); }
+    }
+}

--- a/src/child_frame.rs
+++ b/src/child_frame.rs
@@ -1,42 +1,31 @@
 
 use std::mem::transmute;
 
-use imgui_sys;
-use ImStr;
 use ImVec2;
 use ImGuiWindowFlags;
 
-use super::{
-    ImGuiWindowFlags_NoTitleBar,
-    ImGuiWindowFlags_NoResize,
-    ImGuiWindowFlags_NoMove,
-    ImGuiWindowFlags_NoScrollbar,
-    ImGuiWindowFlags_NoScrollWithMouse,
-    ImGuiWindowFlags_NoCollapse,
-    ImGuiWindowFlags_AlwaysAutoResize,
-    ImGuiWindowFlags_ShowBorders,
-    ImGuiWindowFlags_NoSavedSettings,
-    ImGuiWindowFlags_NoInputs,
-    ImGuiWindowFlags_MenuBar,
-    ImGuiWindowFlags_HorizontalScrollbar,
-    ImGuiWindowFlags_NoFocusOnAppearing,
-    ImGuiWindowFlags_NoBringToFrontOnFocus,
-    ImGuiWindowFlags_AlwaysVerticalScrollbar,
-    ImGuiWindowFlags_AlwaysHorizontalScrollbar,
-    ImGuiWindowFlags_AlwaysUseWindowPadding
-};
+use super::{ImGuiWindowFlags_NoTitleBar, ImGuiWindowFlags_NoResize, ImGuiWindowFlags_NoMove,
+            ImGuiWindowFlags_NoScrollbar, ImGuiWindowFlags_NoScrollWithMouse,
+            ImGuiWindowFlags_NoCollapse, ImGuiWindowFlags_AlwaysAutoResize,
+            ImGuiWindowFlags_ShowBorders, ImGuiWindowFlags_NoSavedSettings,
+            ImGuiWindowFlags_NoInputs, ImGuiWindowFlags_MenuBar,
+            ImGuiWindowFlags_HorizontalScrollbar, ImGuiWindowFlags_NoFocusOnAppearing,
+            ImGuiWindowFlags_NoBringToFrontOnFocus, ImGuiWindowFlags_AlwaysVerticalScrollbar,
+            ImGuiWindowFlags_AlwaysHorizontalScrollbar, ImGuiWindowFlags_AlwaysUseWindowPadding};
 
 #[must_use]
-pub struct ChildFrame<'p> {
-    name: &'p ImStr,
-    size: ImVec2,
-    flags: ImGuiWindowFlags
+pub struct ChildFrame {
+    pub size: ImVec2,
+    pub flags: ImGuiWindowFlags,
 }
 
-impl<'p> ChildFrame<'p> {
-    pub fn new(name: &'p ImStr, size: ImVec2) -> ChildFrame<'p> {
-        let empty_flag: ImGuiWindowFlags = unsafe {transmute::<i32, ImGuiWindowFlags>(0) };
-        ChildFrame { name: name, size: size, flags: empty_flag }
+impl ChildFrame {
+    pub fn new(size: ImVec2) -> ChildFrame {
+        let empty_flag: ImGuiWindowFlags = unsafe { transmute::<i32, ImGuiWindowFlags>(0) };
+        ChildFrame {
+            size: size,
+            flags: empty_flag,
+        }
     }
     #[inline]
     pub fn show_title(mut self, value: bool) -> Self {
@@ -74,7 +63,7 @@ impl<'p> ChildFrame<'p> {
         self
     }
     #[inline]
-    pub fn show_border(mut self, value: bool) -> Self {
+    pub fn show_borders(mut self, value: bool) -> Self {
         self.flags.set(ImGuiWindowFlags_ShowBorders, value);
         self
     }
@@ -105,31 +94,34 @@ impl<'p> ChildFrame<'p> {
     }
     #[inline]
     pub fn bring_to_front_on_focus(mut self, value: bool) -> Self {
-        self.flags.set(ImGuiWindowFlags_NoBringToFrontOnFocus, !value);
+        self.flags.set(
+            ImGuiWindowFlags_NoBringToFrontOnFocus,
+            !value,
+        );
         self
     }
     #[inline]
     pub fn always_show_vertical_scroll_bar(mut self, value: bool) -> Self {
-        self.flags.set(ImGuiWindowFlags_AlwaysVerticalScrollbar, value);
+        self.flags.set(
+            ImGuiWindowFlags_AlwaysVerticalScrollbar,
+            value,
+        );
         self
     }
     #[inline]
     pub fn always_show_horizontal_scroll_bar(mut self, value: bool) -> Self {
-        self.flags.set(ImGuiWindowFlags_AlwaysHorizontalScrollbar, value);
+        self.flags.set(
+            ImGuiWindowFlags_AlwaysHorizontalScrollbar,
+            value,
+        );
         self
     }
     #[inline]
     pub fn always_use_window_padding(mut self, value: bool) -> Self {
-        self.flags.set(ImGuiWindowFlags_AlwaysUseWindowPadding, value);
+        self.flags.set(
+            ImGuiWindowFlags_AlwaysUseWindowPadding,
+            value,
+        );
         self
-    }
-
-    pub fn build<F: FnOnce()>(self, f: F) {
-        unsafe {
-            let show_border = self.flags.contains(ImGuiWindowFlags_ShowBorders);
-            imgui_sys::igBeginChild(self.name.as_ptr(), self.size, show_border, self.flags);
-        }
-        f();
-        unsafe { imgui_sys::igEndChild(); }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use imgui_sys::{ImDrawIdx, ImDrawVert, ImGuiInputTextFlags, ImGuiInputTextFl
                     ImGuiWindowFlags_NoSavedSettings, ImGuiWindowFlags_NoScrollWithMouse,
                     ImGuiWindowFlags_NoScrollbar, ImGuiWindowFlags_NoTitleBar,
                     ImGuiWindowFlags_ShowBorders, ImVec2, ImVec4};
+pub use child_frame::ChildFrame;
 pub use input::{ColorEdit3, ColorEdit4, InputFloat, InputFloat2, InputFloat3, InputFloat4,
                 InputInt, InputInt2, InputInt3, InputInt4, InputText};
 pub use menus::{Menu, MenuItem};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub use style::StyleVar;
 pub use trees::{CollapsingHeader, TreeNode};
 pub use window::Window;
 
+mod child_frame;
 mod input;
 mod menus;
 mod plothistogram;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,6 +1,7 @@
 use imgui_sys;
 use std::marker::PhantomData;
 use std::ptr;
+use child_frame::ChildFrame;
 
 use super::{ImGuiSetCond, ImGuiWindowFlags, ImGuiWindowFlags_AlwaysAutoResize,
             ImGuiWindowFlags_AlwaysHorizontalScrollbar, ImGuiWindowFlags_AlwaysUseWindowPadding,
@@ -157,6 +158,9 @@ impl<'ui, 'p> Window<'ui, 'p> {
         self.flags
             .set(ImGuiWindowFlags_AlwaysUseWindowPadding, value);
         self
+    }
+    pub fn with_child(&self, size: ImVec2) -> ChildFrame<'p> {
+        ChildFrame::new(self.name, size)
     }
     pub fn build<F: FnOnce()>(self, f: F) {
         let render = unsafe {


### PR DESCRIPTION
 Hello!  I needed to expose more functionality from imgui. Here's my initial idea for supporting child frame's within a window.

    Imgui allows the user to create child frame's, and render into them.
    This isn't exposed currently, this is my first idea at how rust can
    support child frame's.

    Presently it's not the easiest to use, to have a window with a child
    frame supported, internally the imgui library must have called
    beginWindow() for the parent window, before beginChild() is ever called
    for the child frame. Doing this without causing unneeded
    allocations/complexity, and making the API ergonomic is something I hope
    to work on next / get some feedback on.

Functionally, I believe this code to be correct. I have an example of how client code looks using this, and how it renders on my machine here:
![imgui_child_window](https://user-images.githubusercontent.com/1087837/27890881-9a7913d4-61aa-11e7-956c-f1fc64b1f751.png)

I'm pretty unhappy that I ended up with a second self-consuming build() method on the window builder. The fact that I need to pass in two closure's forced me to do this for now, at least until I figure out how to store a closure without a dynamic allocation.

Things I'd like to make better / get some help with:

1. Allow the user to pass in a closure to a member function of the window builder, instead of an additional parameter to the build_with_child_frame() method, add another method to the Window type, that takes the user's function and store's it (so it can be called during build()).
    *  I did some work on this, I added a new field to the Window struct which had the type Option<fn() -> ()>, but the compiler wouldn't let me pass in a closure and store it as a plain function pointer. Do you have any ideas on how we might store a function pointer / closure without an additional allocation? I would think an additional data member on the Window struct would be fine, as long as it is not dynamically allocated.

2. Consolidate back to a single build() method taking a single closure, like the original design, still supporting child frame's though. Right now it's awkward to pass in both closure's like this, the original design made more sense. I get this for free by completing #1 above. If the user can pass in a closure for constructing the child frame, there's no need for the second build_with_child_frame() method.

3. Support arbitrarily nested child-frames. Imgui supports nesting arbitrary frame's, right now this design only supports a maximum of one child frame.